### PR TITLE
Fix OpenCV package name

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 flask
-opencv
+opencv-python
 matplotlib


### PR DESCRIPTION
## Summary
- fix invalid `opencv` dependency by switching to `opencv-python`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68764ad66bfc832b8070b6aebcb6b7a5